### PR TITLE
Fix navnefelt som glitcher grunnet autowidth

### DIFF
--- a/src/components/InlineInput.jsx
+++ b/src/components/InlineInput.jsx
@@ -60,13 +60,16 @@ class InlineInput extends React.Component {
     }
 
     render() {
-        const { id, placeholder, maxLength, className } = this.props;
+        const { id, placeholder, maxLength, minWidth, className } = this.props;
 
         return (
             <Fragment>
                 <div
                     id={`hidden-${id}`}
                     ref={ref => (this.divElement = ref)}
+                    style={{
+                        minWidth: minWidth != null ? minWidth : "auto"
+                    }}
                     className="inline inline-input__input"
                 >
                     {this.state.value || placeholder}

--- a/src/pages/kontakt.jsx
+++ b/src/pages/kontakt.jsx
@@ -118,6 +118,7 @@ class IndexPage extends React.Component {
                                             placeholder={'Ola Nordmann'}
                                             onChange={this.onNameChanged}
                                             maxLength="20"
+                                            minWidth="320px"
                                         />
                                         <div className="">
                                             og mitt telefonnummer er&nbsp;


### PR DESCRIPTION
**Problem:**
Navnefelt på kontakt oss siden hopper opp på linjen over når width blir lavere enn 320px. 320px er default verdien, men reduseres i det man skriver inn en bokstav.

**Løsning:**
Sette minWidth på feltet slik at den aldri kan bli mindre enn 320px.

Fikser #23 