### PR TITLE
refaktorerer forsiden og ansattesiden til å være mer dynamisk

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,5 +27,5 @@ module.exports = {
             },
         },
     ],
-    pathPrefix: '/next',
+    pathPrefix: '/',
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,5 +3,60 @@
  *
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
+var ansatte = require('./src/ansatte');
+// You can delete this file if you're not using it
 
- // You can delete this file if you're not using it
+function showAvailableConsultantsFirst(a, b) {
+    const employeeA = a;
+    const employeeB = b;
+
+    let employeeAScore = generateEmployeeSortScore(employeeA);
+    let employeeBScore = generateEmployeeSortScore(employeeB);
+
+    return employeeAScore - employeeBScore;
+}
+
+function generateEmployeeSortScore(employee) {
+    if (employee.isConsultant === false) {
+        return 99999999;
+    }
+
+    if (employee.endOfContract) {
+        const endOfContractAsNumber = Number.parseInt(
+            employee.endOfContract.replace(/-/gi, '')
+        );
+        if (!Number.isNaN(endOfContractAsNumber)) {
+            return endOfContractAsNumber;
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+exports.createPages = async ({
+    actions: {
+        createPage
+    }
+}) => {
+    const sortedAnsatte = Object.keys(ansatte).map(key => ({
+        ...ansatte[key],
+        key
+    })).sort(showAvailableConsultantsFirst);
+
+
+    createPage({
+        path: `/ansatte`,
+        component: require.resolve("./src/pages/ansatte/alle-ansatte.jsx"),
+        context: {
+            ansatte: sortedAnsatte
+        },
+    });
+    createPage({
+        path: `/`,
+        component: require.resolve("./src/pages/forsiden.jsx"),
+        context: {
+            ansatte: sortedAnsatte.slice(0, 3)
+        },
+    });
+}

--- a/src/ansatte-med-assets.js
+++ b/src/ansatte-med-assets.js
@@ -72,9 +72,7 @@ import Cards from './images/cards.jpeg';
 import Music from './images/music_lover.jpeg';
 import Yoga from './images/yoga.jpeg';
 import ansatte from './ansatte';
-import {
-    showAvailableConsultantsFirst
-} from './utils';
+import { showAvailableConsultantsFirst } from './utils';
 
 export const ansatteMedAssets = {
     toreric: {

--- a/src/ansatte.json
+++ b/src/ansatte.json
@@ -1,0 +1,585 @@
+[
+    "toreric": {
+        "name": "Tor Eric Sandvik",
+        "title": "Daglig leder",
+        "endOfContract": null,
+        "showOnFirstPage": false,
+        "isConsultant": false,
+        "firstName": "Tor Eric",
+        "ingress": "Tor Eric er utdannet som Master i Informatikk og har 15 års erfaring i IT-bransjen. Han har bred erfaring som blant annet prosjektleder, Scrum Master, konsulentsjef, rådgiver, styremedlem og produkteier.",
+        "keyFeatures": [
+            "Daglig leder",
+            "Prosjektleder",
+            "Konsulentsjef",
+            "Scrum Master utvikling",
+            "Produkteier",
+            "PRINCE2"
+        ],
+        "email": "toreric@scelto.no",
+        "linkedIn": "torericsandvik",
+        "twitter": "torericsandvik",
+        "mainSection": [
+            "Han har lang erfaring i å lede større utviklingsprosjekter. Han er en sterk pådriver som har stort fokus på smidig prosjektgjennomføring.",
+            "Tor Eric har jobbet mye med e-handel og internettløsninger, og har blant annet hatt ansvaret for en nyskapende og komplett e-handelsløsning for tannteknikerbedriften Proteket. Proteket Online vant gulltaggen for beste e-handelsløsning i 2009. Tor Erics referanser omtaler ham som en handlekraftig mann som er strukturert, resultatorientert, samarbeidsvillig og selvstendig.",
+            "Teamleder med agile metoder som Scrum og Kanban. Prosjektledelse med PRINCE2 og bruk av SSA-V, SSA-S og SSA-T. Rådgiver med bruk av PS 2000 SOL avtalen."
+        ]
+    },
+    "oletommy": {
+        "name": "Ole Tommy Lid-Strand",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Ole Tommy",
+        "ingress": "Ole Tommy har over 12 års erfaring fra IT bransjen. Er utdannet Master of Informatics. og opparbeidet seg har bred erfaring fra etablering og innføring av IT løsninger for flere ulike bransjer. Han har fungert i rollen som utvikler/arkitekt i flere prosjekter for kunder som Eidsiva Energi, Hafslund og Canal Digital og Eika Alliansen. En stor tilhenger av åpen kildekode og av å gjøre ting enkelt.",
+        "keyFeatures": [
+            "Integrasjonsspesialist",
+            "Java-utvikler",
+            "Applikasjonsforvaltning",
+            "Teknisk arkitekt",
+            "SOA",
+            "Mule",
+            "Oracle"
+        ],
+        "email": "ole.tommy@scelto.no",
+        "linkedIn": "oletls",
+        "twitter": "oletls",
+        "github": "oletls",
+        "mainSection": [
+            "Med mer en 12 års erfaring fra bransjen har Ole Tommy jobbet med mange ulike teknologier som COBOL, Java, C++ og integrasjonsrammeverk fra Mule, Oracle og JBoss. De siste 10 årene har han i hovedsak jobbet med SOA integrasjonsprosjekter i ulike former.",
+            "Ole Tommy har høy arbeidskapasitet, er strukturert og resultatorientert. Han har god evne til å ta tak i nye problemstillinger. Han er fleksibel, åpen og passer lett inn i nye miljøer. På fritiden er han en ivrig gamer og sykkelentusiast, som også er innom litt løping og svømming av og til."
+        ]
+    },
+    "herman": {
+        "name": "Herman Crawfurd Svensen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-06-30",
+        "firstName": "Herman",
+        "ingress": "Herman er teknisk arkitekt og senior .NET-utvikler med erfaring fra frontend-utvikling til database. I tillegg har han god kjennskap til Java-utvikling og har dermed en bred plattform som løsningsarkitekt. Herman er M.Sc i informasjonsteknologi, er TOGAF9-sertifisert, sertifisert Scrum Master og Microsoft-sertifisert utvikler innen web og sky. I de senere år har han også jobbet med både Microsoft Azure og Amazon Web Services, og jobber nå med sertifiseringløp på begge disse skyplattformene (Microsoft Certified: Azure Solutions Architect Expert og AWS Certified Cloud Practitioner).",
+        "keyFeatures": [".NET", "Systemutvikling", "Teknisk arkitekt", "DevOps"],
+        "email": "herman@scelto.no",
+        "linkedIn": "hermancs",
+        "twitter": "herms_cs",
+        "github": "herms",
+        "mainSection": [
+            "Herman er flink til å sette seg inn i nye bransjer og domener, og synes dette er noe av det mest spennende med jobben. Han har jobbet i store prosjekter hos store kunder, og små prosjekter hos små kunder, i både store og små team. Selv om han trives best i velfungerende team der kunnskapsdeling står i fokus, står han også godt på egne ben. Herman ønsker stadig å utvikle seg, og deler også mer enn gjerne sin egen kunnskap.",
+            "Herman er en god lagspiller som sprer godt humør, er ydmyk, og etterstreber høy personlig og profesjonell integritet. På fritiden liker han å nyte naturen, helst med ski på - både oppover, nedover og til nød bortover. Dessuten en smarthusentusiast som jobber med å automatisere og forenkle hverdagen i hjemmet."
+        ],
+        "testimonial": {
+            "text": "Over the last few years, Herman has played a critical role to take Santander’s risk origination systems to a new level. Passion, enthusiasm and can-do attitude, as well as dedication and commitment to the project and the company, are the words that best define him. His capacity to solve complex business challenges, his agile mindset, together with a deep technical knowledge are the key competences that have made his time in Santander a story of success.",
+            "customer": "Santander",
+            "person": "Manuel Siñeriz",
+            "position": "Risk Decision Systems Manager",
+            "year": 2018
+        }
+    },
+    "haaken": {
+        "name": "Håken Stark",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-12-31",
+        "firstName": "Håken",
+        "ingress": "Håken Stark har 12 års erfaring fra IT bransjen, og har lang erfaring med utvikling av moderne webapplikasjoner i rollen som både utvikler og prosjektleder. Han er spesielt interessert i utvikling, brukerdesign og smidige prosjektmetoder.",
+        "keyFeatures": [
+            "Java",
+            "Angular & Frontend",
+            "Scrum Master",
+            "Teamleder",
+            "Teknisk arkitekt"
+        ],
+        "email": "haaken@scelto.no",
+        "linkedIn": "haakens",
+        "twitter": "haakenstar",
+        "github": "haakens",
+        "mainSection": [
+            "Han har blant annet erfaring som utvikler på prosjekter i India, og har i mer enn 8 år jobbet i prosjekter som omfatter utvikling av webapplikasjoner basert på Java.",
+            "Han har også mer enn fire års erfaring som Scrum Master og prosjektleder hvor han har jobbet med kunder som Agder Energi, Hafslund, Proteket og Statoil Fuel and Retail.",
+            "Håken Stark har høy arbeidskapasitet, er strukturert og resultatorientert. Han er selvstendig, men er samtidig åpen og lett å samarbeide med. Han er veldig engasjert i arbeidet sitt, og tror sterkt på å skape gode brukeropplevelser og forretningsverdier for kunden ved å benytte en smidig tilnærming."
+        ]
+    },
+    "marius": {
+        "name": "Marius Aune Gravdal",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-08-31",
+        "firstName": "Marius",
+        "ingress": "Marius har jobbet som utvikler i over 10 år, med over 8 års erfaring fra energi bransjen. Han er en potet og liker like godt å drive med utvikling som å sette opp infrastruktur.",
+        "keyFeatures": [
+            "Teknisk arkitekt",
+            "Java",
+            "Systemutvikler",
+            "Integrasjonsutvikler",
+            "REST"
+        ],
+        "email": "marius@scelto.no",
+        "linkedIn": "mariusgravdal",
+        "twitter": "xoiram",
+        "github": "xoiram",
+        "mainSection": [
+            "Marius er engasjert og liker å dele kunnskapen han tilegner seg med andre for å gjøre teamet han jobber i best mulig.",
+            "Han brenner for smidig utvikling, men innser at det ikke er noen holy-grail som løser alle utfordringene et utviklingsprosjekt møter. Etter over 10 år i bransjen og en rekke prosjekter har han tilegnet seg en bred kompetanse over en rekke områder, med vekt på energi bransjen hvor han har jobbet med både måleverdi-, drifts-støttesystemer og nå sist den nasjonale datahuben for energibransjen, Elhub. I forbindelse med disse prosjektene har han også opparbeidet seg mye kompetanse på migrering, og kompleksiteten forbundet med dette."
+        ]
+    },
+    "oleandre": {
+        "name": "Ole-André Riga-Johansen",
+        "firstName": "Ole André",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "ingress": "Ole-André er ekspert på moderne webapplikasjoner og nettskyarkitektur. Han har opparbeidet god forståelse og erfaring med evaluering og utvikling av slike systemer fra bakside til fremside, og er sertifisert innen .NET, JavaScript og Java.",
+        "keyFeatures": [
+            "Java / .NET",
+            "FullStack",
+            "FullStack",
+            "Systemutvikler",
+            "Teknisk Arkitekt",
+            "Cloud-arkitektur",
+            "REST"
+        ],
+        "email": "ole-andre@scelto.no",
+        "linkedIn": "tuxbear",
+        "twitter": "tuxbear",
+        "github": "tuxbear",
+        "mainSection": [
+            "Som teknolog er Ole-André opptatt av grenselandet mellom teknologi og forretningsverdi. Han er en engasjert, entusiastisk og motivert person som er et positivt tilskudd til ethvert team. På fritiden er Ole-André fotballsupporter, reiseentusiast og aksjespekulant."
+        ]
+    },
+    "gustav": {
+        "name": "Gustav Bilben",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Gustav",
+        "ingress": "Gustav er en erfaren systemutvikler, team-leader og arkitekt. Han har over 15 års erfaring med utvikling av javabaserte systemer fra både offentlig, bla. PDMT, og privat sektor.",
+        "keyFeatures": ["Systemutvikling", "Teamleder", "Teknisk arkitekt"],
+        "email": "gustav@scelto.no",
+        "linkedIn": "gbilben",
+        "twitter": "gbilben",
+        "github": "gustavb",
+        "mainSection": [
+            "Han har jobbet med mange forskjellige typer utviklingsoppgaver og har bred erfaring med utvikling og design av integrasjon- og kommunikasjonsløsninger.",
+            "Gustav liker å dele sine kunnskaper med andre og har hatt en mentor rolle både formelt og uformelt i de prosjektene han har jobbet."
+        ]
+    },
+    "erlend": {
+        "name": "Erlend Nilsen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Erlend",
+        "ingress": "Erlend er en erfaren arkitekt og systemutvikler som trives med å være høyt og lavt. Forståelse for kundens domene og forretning er alltid fundamentet – mer effektive og treffsikre it-løsninger er alltid målet.",
+        "keyFeatures": [
+            "Teknisk arkitekt",
+            "Integrasjonsutvikling",
+            "Analyse og design"
+        ],
+        "email": "erlend@scelto.no",
+        "linkedIn": "erlend-nilsen-743aa6b6",
+        "twitter": "erlendkleppen",
+        "mainSection": [
+            "Erlend har gjennom mer enn ti år opparbeidet seg bred erfaring fra mange ulike roller i store utviklingsprosjekter. Som arkitekt, tech lead og utvikler jobber han helst med Java-baserte back-end-løsninger og integrasjoner. Like gjerne jobber han med å kartlegge og forbedre forretningsprosesser. Uavhengig av rolle og arbeidsoppgaver er Erlend positiv, lærevillig og pilktoppfyllende og har vist evne til å levere resultater etter kort tid.",
+            "Erlend forstår raskt nye domener og jobber godt med forretning og brukere. Med god fremstillingsevne, både skriftlig og muntlig , trives han godt med å jobbe mot kundens partnere, leverandører og egne kunder, nasjonalt og internasjonalt.",
+            "De siste fem årene har Erlend opparbeidet seg en unik prosess- og domeneforståelse innenfor energi-domenet generelt og AMS/smart grid spesielt gjennom sine roller som produkteier, løsningsarkitekt og technical lead i Embriqs produktportefølje for MDM og AMS (Quant).",
+            "Utenfor arbeidstiden er Erlend en sterkt plaget tilhenger av Lillestrøm sportsklubb."
+        ]
+    },
+    "richard": {
+        "name": "Richard Rennemo",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Richard",
+        "ingress": "Richard er en dreven og pragmatisk fullstack-programmerer med DevOps-kompetanse. Teamleder og miljøskaper. Forkjærlighet for gode og brukervennlige frontend-løsninger",
+        "keyFeatures": [
+            "Java",
+            "Javascript",
+            "Systemutvikler",
+            "Brukeropplevelse",
+            "DevOps",
+            "Teamleder",
+            "Teknisk arkitekt"
+        ],
+        "email": "richard@scelto.no",
+        "linkedIn": "richardrennemo",
+        "twitter": "rennemo",
+        "github": "richardrennemo",
+        "mainSection": [
+            "Richard er en erfaren systemutvikler med svært god kompetanse på både frontend og backend.",
+            "Alt fra Oracle-databaser til HTML5 og CCS3 står på timeplanen og han jobber daglig med DevOps. Han er pragmatiker og forkjemper for ren, lesbar og ukomplisert kode. I team fungerer han like godt som teamleder og team-medlem. Han er et positivt tilskudd til ethvert miljø, og er spesielt flink til å få samarbeidsprosser til å fungere, Han han har også lett for å forstå forretningprosesser samt å forstå brukerbehov og bearbeide gode løsningsbeskrivelser sammen med brukere og kunder. Richard er også en ivrig quizzer og dataspiller. Fordi kunnskap og lek er viktig!"
+        ]
+    },
+    "erik": {
+        "name": "Erik Salhus",
+        "firstName": "Erik",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-06-30",
+        "ingress": "Erik er en engasjert senior systemutvikler med meget god kompetanse på både frontend- og backend-utvikling. Erik har mye erfaring ved bruk av moderne webrammeverk og har fokus på å skrive lesbar kode med funksjonell nytte",
+        "keyFeatures": [
+            "FullStack",
+            "Javascript",
+            "ECMAScript 6+",
+            "Java",
+            "Node.js",
+            "Android"
+        ],
+        "email": "erik@scelto.no",
+        "linkedIn": "eriksalhus",
+        "twitter": "eriksalhus",
+        "github": "eriksalhus",
+        "mainSection": [
+            "Erik har god erfaring med utvikling av kundebaserte webløsninger. De siste årene har han jobbet for SPK, Gjensidige og NorgesGruppen både som løsningsarktitekt, utvikler og scrum master.",
+            "Erik er en ansvarsbevisst teammedarbeider og liker å drive utviklingen fremover. Han har lang erfaring med arbeid i miljø hvor automatiserte tester, kontinuerlig utvikling og hyppige lanseringer er standard rutine."
+        ]
+    },
+    "janerik": {
+        "name": "Jan Erik Svendsen ",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Jan Erik",
+        "ingress": "Jan Erik er en fullstack systemutvikler med bred erfaring fra flere nyere front-end/JS rammeverk.",
+        "keyFeatures": [
+            "Java",
+            "Systemutvikler",
+            "FullStack",
+            "REST",
+            "Scala",
+            "Smidig/Agile"
+        ],
+        "email": "jan.erik@scelto.no",
+        "twitter": "janeriksvendsen",
+        "github": "janeriksvendsen",
+        "mainSection": [
+            "Jan Erik Svendsen, født 1971, har 19 års erfaring fra IT bransjen. Han har bred erfaring fra utvikling av IT løsninger for flere ulike bransjer.",
+            "Jan Erik har erfaring med utvikling, design og integrasjon av store systemer og god forståelse for forretningsbehov."
+        ]
+    },
+    "ivar": {
+        "name": "Ivar Nilsen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Ivar",
+        "ingress": "Ivar har en master i informasjonsteknologi fra NTNU og har 10 års erfaring som utvikler. Han har jobbet på både store og små prosjekter og med mange forskjellige teknologier.",
+        "keyFeatures": [
+            "Javascript",
+            "ECMAScript 2015",
+            "React.js",
+            "Node.js",
+            "Webteknologi",
+            "Java"
+        ],
+        "email": "ivar@scelto.no",
+        "linkedIn": "ivarni",
+        "twitter": "ivarni",
+        "github": "ivarni",
+        "mainSection": [
+            "Han de senere årene fokusert på å bygge kompetanse på webløsninger og Javascript-teknologier og jobber ofte med å prøve ut nye teknologier.",
+            "Ivar har vært på flere prosjekter innen finans, offentlig sektor og luftfart. Han har vært team-arkitekt hos Statens Pensjonskasse's PERFORM prosjekt og Technical Lead for et prosjekt i oppstartsfasen på Oslo Lufthavn Gardermoen.",
+            "Ivar har erfaring med og kunnskap om populære frontend-rammeverk som Angular og React og er vant til å jobbe med moderne byggverktøy som Babel og Webpack."
+        ]
+    },
+    "vetle": {
+        "name": "Vetle Valebjørg",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-01-31",
+        "firstName": "Vetle",
+        "ingress": "Vetle Valebjørg er en erfaren systemutvikler med hovedfokus på javabaserte systemer. Hans erfaring omfatter design og utvikling av applikasjoner med webbaserte grensesnitt, de siste årene hos oppdragsgivere innen bank og forsikring.",
+        "keyFeatures": [
+            "Teknisk arkitekt",
+            "Systemutvikler",
+            "Java",
+            "Fullstack"
+        ],
+        "email": "vetle@scelto.no",
+        "linkedIn": "",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Vetle er en senior systemutvikler med erfaring fra større IT-prosjekter som kan  bidra med utforming av krav, diskusjon av løsninger og arkitektur hos sine oppdragsgivere.",
+            "Han er vant til å ta et selvstendig ansvar for nyutvikling og forvaltning, og blir ofte en nøkkelperson for sine oppdragsgivere. Under digitalisering av prosesser er han opptatt av - og ser mulighetene for automatisering og prosessforbedringer.",
+            "Vetle er en person som tar ansvar og initiativ. Han er nøye og setter høye krav til seg selv når det gjelder kvalitet og leveranse. Som eksempel, kan det nevnes at Vetle utviklet en data- og nøkkelorddrevet test, som ga kunden en fleksibel, grundig og automatisert regresjonstest av systemet ved nye leveranser. "
+        ]
+    },
+    "sean": {
+        "name": "Seán Erik Scully",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Seán",
+        "ingress": "Seán er en JavaScript-ekspert som primært har jobbet med mobile flater — både native og web. Han er opptatt av å holde seg oppdatert faglig, noe han viser ved å være aktiv i Open Source-miljøet og inneha flere sertifiseringer relevante for sitt fagområde.",
+        "keyFeatures": [
+            "GraphQL",
+            "React",
+            "NodeJS",
+            "iOS/Android",
+            "Webpack",
+            "Javascript/ES5+",
+            "HTML/CSS"
+        ],
+        "email": "sean@scelto.no",
+        "linkedIn": "",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Seán Erik Scully har jobbet med utvikling av grensesnitt for mobil og web i snart fire år. Gjennom flere prosjekter har han opparbeidet seg ekspertkompetanse på frontend-stacken, og har arbeidet tett både med UX- og designere for å gi gode brukeropplevelser så vel som gode visuelle inntrykk.",
+            "Utover bachelorgrad innen IT fra UiO, kan Seán — som eneste i Scelto —ta seg smukt ut med en mastergrad i latin."
+        ]
+    },
+    "ken": {
+        "name": "Ken Gullaksen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-12-31",
+        "firstName": "Ken",
+        "ingress": "Ken er en selvdreven, kvalitetsbevisst og disiplinert full-stack utvikler med over ti års erfaring innen systemutvikling. Han jobber med utvikling, design og arkitektur, og har en nese for gode brukeropplevelser.",
+        "keyFeatures": [
+            "Java",
+            "Javascript",
+            "Ruby",
+            "Systemutvikling",
+            "DevOps",
+            "Teknisk arkitekt"
+        ],
+        "email": "ken@scelto.no",
+        "linkedIn": "kengullaksen",
+        "twitter": "kenglxn",
+        "github": "kenglxn",
+        "mainSection": [
+            "Ken er dyktig i flere programmeringsspråk og er sertifisert Oracle Java utvikler. Han har erfaring fra flere store prosjekter og kodebaser, og kjenner det som må til for å gjøre kode vedlikeholdbar og robust nok til å tåle tidens tann. Ken har lang erfaring med DevOps og kontinuerlig utrulling av store systemer.",
+            "Ken er hyggelig og flink til å kommunisere både med kunder og teknikere. Han er mottakerbevisst, og har en god evne til å finne frem til løsninger som gir mest verdi for innsatsen. Ken er en OSS entusiast og har bidratt til flere kjente Open Source biblioteker, samt publisert en del av sine egne. Hans mest populære, som ble publisert i 2012, har over 800 stjerner på github.",
+            "Ellers er Ken en blid og hyggelig person som på fritiden driver med karate og bygger ting til sine to døtre."
+        ]
+    },
+    "larsfredrik": {
+        "name": "Lars Fredrik Lunde",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2020-08-31",
+        "firstName": "Lars Fredrik",
+        "ingress": "Lars Fredrik er en fremadstormende og engasjert systemutvikler som har spesialisert seg på utvikling og vedlikehold av løsninger basert på C#.",
+        "keyFeatures": ["Systemutvikler", ".Net", "Fullstack", "Webteknologier"],
+        "email": "vetle@scelto.no",
+        "linkedIn": "",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Lars Fredrik er dyktig på interaksjon med brukergrupper, og jobber aktivt for å bedre brukeropplevelsen i sine prosjekter. I sitt daglige arbeide har han fokus på å levere høy kvalitet på det han utvikler i henhold til best practice i samarbeid med prosjektteamet.",
+            "Han liker å holde seg oppdatert på teknologi og trender, samt å dele denne kunnskapen med andre i fagmiljøet. Han har blant annet hatt rollen som fagansvarlig innen .NET-miljøet og er Microsoft Sertified Developer. I tillegg har Lars Fredrik 10 års erfaring med utvikling av webløsninger.",
+            "Ellers er Lars Fredrik en driftig, utadvendt og ansvarsfull ressurs som tilstreber å yte sitt beste på hvert prosjekt."
+        ]
+    },
+    "fredrikb": {
+        "name": "Fredrik Bjørnøy",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Fredrik",
+        "ingress": "Fredrik har lang erfaring innen systemutvikling og hans spesialkompetanse er på Java-platformen. Han har erfaring fra flere store komplekse prosjekter i offentlig og privat sektor som Statens Vegvesen, Telenor og SPK.",
+        "keyFeatures": ["Systemutvikler", "Java", "Teknisk arkitekt"],
+        "email": "fredrikb@scelto.no",
+        "linkedIn": "",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Fredrik er opptatt av god craftmanship, design og clean code og har brukt mye tid på dette opp igjennom årene.",
+            "Fredrik er en veldig sosial person og er glad i å kjøre alpint på vinteren og ta seg en løpetur ute når været er litt varmere."
+        ]
+    },
+    "fredriks": {
+        "name": "Fredrik Svensen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Fredrik",
+        "ingress": "Fredrik er en dyktig senior systemutvikler med bred kompetanse gjennom hele .Net-stacken. Han har god erfaring med både små webapper og større nett-løsninger ved bruk av moderne rammeverk som Angular og Unity3D.",
+        "keyFeatures": [
+            "Systemutvikler",
+            ".Net",
+            "Fullstack",
+            "DevOps",
+            "Scrum Master"
+        ],
+        "email": "fredriks@scelto.no",
+        "linkedIn": "",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Fredrik har god erfaring med utvikling av helsebaserte webløsninger og hybrid-apper. Etter studiene har han jobbet for Senter for pasientmedvirkning og samhandlings-forskning i 12 år, som DevLead, DevOps, utvikler og Scrum master. Her hadde han også ansvar for oppsett og drift av drifts-, bygg- og testservere, samt avdelingens hardware generelt.",
+            "Han er en entusiastisk og dreven C#-utvikler som har mye fokus på å skrive lesbar og testbar kode med funksjonell nytte. Han er, som en ekte Uncle Bob-disippel, veldig glad i både å forenkle og å slette kode.",
+            "På privaten er Fredrik en svært omgjengelig tobarnsfar som elsker å reise, lage mat, høre på vinyl og fotografere."
+        ]
+    },
+    "terje": {
+        "name": "Terje Lønøy",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Terje",
+        "ingress": "Terje har stor interesse for moderne teknologi, design og gode brukeropplevelser. Han han har jobbet med utvikling av web og applikasjoner for mobil siden 2012.",
+        "keyFeatures": ["iOS", "Android", "Web frontend"],
+        "email": "terje@scelto.no",
+        "linkedIn": "https://www.linkedin.com/in/terje-l%C3%B8n%C3%B8y-a8543165/",
+        "twitter": "terjelonoy",
+        "github": "TerjeLon",
+        "mainSection": [
+            "Terje har vist sterkt faglig engasjement gjennom å avholde mange kurs og workshops, både internt og eksternt, samt være en aktiv pådriver for interne faggrupper innenfor frontend og mobil.",
+            "Han er en sosial og kreativ person som drives av utfordringer og tørst for kunnskap, selv i stressende situasjoner. Videre er han selvstendig, men jobber godt sammen med andre."
+        ]
+    },
+    "larsolav": {
+        "name": "Lars Olav Torvik",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Lars Olav",
+        "ingress": "Lars Olav er en dyktig senior systemutvikler med over 14 års erfaring med frontend-utvikling. Han lang erfaring med både små og store webapper ved bruk av moderne rammeverk som React og Angular.",
+        "keyFeatures": ["Frontend", "Fullstack", "Java"],
+        "email": "larsolav@scelto.no",
+        "linkedIn": "larsolavtorvik",
+        "twitter": "",
+        "github": "lotorvik",
+        "mainSection": [
+            "Selv om Lars Olav er fullstack utvikler er det frontend-utvikling han virkelig brenner for. Det er viktig for han at webløsningene han lager er brukervennlige med responsivt design og han elsker prosjekter hvor han får laget løsninger som oppfyller kravene til en Progressive Web App (PWA).",
+            "De siste årene har han jobbet for Giant Leap Technologies og deres kunder, som tech lead for webutvikling. Her har han fått være involvert i alle nivåer av løsningsprosessen. Lars Olav er en ansvarsbevisst teammedarbeider og liker å drive utviklingen fremover.På privaten er Lars Olav en meget sosial person som er glad i å trene agility med hundene sine og jobbe med hobbyprosjekter."
+        ]
+    },
+    "jarle": {
+        "name": "Jarle Berentzen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Jarle",
+        "ingress": "Jarle har jobbet i IT-bransjen siden 2004, og har bred erfaring som systemutvikler, teknisk arkitekt og teamleder. Fokuset hans har vært på Java-teknologi og integrasjon mellom systemer men han har også jobbet noe i front-end og med mobil teknologi.",
+        "keyFeatures": ["Java", "Integrasjon", "Teknisk Arkitekt"],
+        "email": "jarle@scelto.no",
+        "linkedIn": "jarle-berentzen-59a23821",
+        "twitter": "jberentzen",
+        "github": "jarledb",
+        "mainSection": [
+            "I hans arbeid som systemutvikler har han ofte hatt et sterkt fokus på automatisering av manuelle oppgaver og utvikling av forretningslogikk. Som arkitekt har Jarle hatt høy fokus på modularisering, strukturering og standardisering av kode.",
+            "Jarle er en dedikert teknolog som er faglig interessert og oppdatert på rammeverk og teknologier. Jarle har erfaring med Smidig utvikling både som utvikler og som teamleder/scrum master.",
+            "Jarle er en god og ryddig kommunikator som inngir tillit både for kunden og blant øvrige teammedlemmer. Han evner også å sette seg inn i kundens forretning, mål og planer. Jarle trives veldig godt i dialog med kunden, og han liker å jobbe i selvorganiserende team hvor man han utfylle hverandre."
+        ]
+    },
+    "jantore": {
+        "name": "Jan Tore Stølsvik",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Jan Tore",
+        "ingress": "Jan Tore jobber som systemutvikler med hovedinteresse for React og GraphQL. Han har stort fokus på best practise og smidige metoder.",
+        "keyFeatures": ["React", "Frontend", "Java"],
+        "email": "jan.tore@scelto.no",
+        "linkedIn": "jan-tore-stølsvik-49320a81",
+        "twitter": "",
+        "github": "jantorestolsvik",
+        "mainSection": [
+            "Jan Tore jobber som systemutvikler med hovedinteresse for React og GraphQL. Han har stort fokus på best practise og smidige metoder.",
+            "Som følge av et utvekslingsår i Singapore har han jobbet på flere prosjekter med internasjonale studenter og kommuniserer derfor like godt på engelsk som på norsk. Jan Tore har holdt foredrag mange ganger på f.eks. JavaZone og NDC.",
+            "Jan Tore arbeider hardt, er positiv og løsningsorientert i møte med utfordrende oppgaver. Han er glad i å lære nye ting og jobber godt sammen med andre, samtidig som han er selvstendig."
+        ]
+    },
+    "annkatrin": {
+        "name": "Ann Katrin Gagnat",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Ann Katrin",
+        "ingress": "Ann Katrin har en mastergrad i informatikk, og er en engasjert systemutvikler med bransjeerfaring innen forsikring, luftfart, pensjon og e-handel.",
+        "keyFeatures": ["Systemutvikling Java", "Fullstack utvikler"],
+        "email": "ann.katrin@scelto.no",
+        "linkedIn": "akgagnat",
+        "twitter": "akgagnat",
+        "github": "akgagnat",
+        "mainSection": [
+            "Siden starten av karrieren i 2005 har hun jobbet med programmering, og hun trives både frontend og backend.",
+            "Hun blir gjerne med i alle faser fra kravspesifikasjon til forvaltning av systemene, og har tilegnet seg god evne til å se helheten i løsningene.",
+            "Som person har Ann Katrin en positiv innstilling, og hun jobber godt både i team og selvstendig."
+        ]
+    },
+    "jorgen": {
+        "name": "Jørgen Ringen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Jørgen",
+        "ingress": "Jørgen har erfaring fra 2011 som systemutvikler og teknisk arkitekt. Han har solid erfaring fra flere store komplekse prosjekter i offentlig og privat sektor som Statens Vegvesen, Telenor, NAV og Ruter.",
+        "keyFeatures": [
+            "Systemutvikler Java",
+            "Teknisk arkitekt",
+            "Applikasjonsarkitektur",
+            "Mikrotjenester",
+            "Cloudteknologi"
+        ],
+        "email": "jorgen@scelto.no",
+        "linkedIn": "jorgenringen",
+        "twitter": "jorgenringen",
+        "github": "JorgenRingen",
+        "mainSection": [
+            "Han er en engasjert utvikler som brenner for faget. Han har sine primære kompetanseområder innenfor java og økosystemet rundt teknologien hvor han har tatt en rekke sertifiseringer på ulike nivåer. Han har også høy kompetanse og interesse innenfor mikrotjenestearkitektur, hendelsesdrevet arkitektur, cloudteknologi, DevOps, smidig arbeidsmetodikk og software craftsmanship.",
+            "Jørgen er lidenskapelig opptatt av hvordan teknologi og digitalisering kan skape verdi hos sluttbruker. Han er forkjemper for at noe av det aller viktigste som skal til for å kunne bygge virkelig gode tekniske løsninger, som står seg over tid, er at man har dyp innsikt i kundens unike domene og forretningsprosesser.",
+            "Jørgen har høy arbeidskapasitet, er strukturert og forutsigbar og opptatt av å levere resultater. Han jobber selvstendig, men er også åpen og lett å samarbeide med. Han har hatt flere roller på prosjekter hvor han har vært ansvarlig for opplæring og coaching av andre, blant annet som development lead hos Telenor og som teknisk arkitekt i SCRUM-team.",
+            "På fritiden er Jørgen en sosial person. Han er interessert i friluftsliv og har stor interesse for løping, langrenn og seiling."
+        ]
+    },
+    "baard": {
+        "name": "Bård Dybwad Kristensen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Bård",
+        "ingress": "Bård har lang og bred erfaring innen utvikling av it–løsninger og har jobbet i flere store prosjekter. Han har meget god kunnskap innen Java og J2EE utvikling og har jobbet kontinuerlig med denne teknologien siden 1999.",
+        "keyFeatures": ["Java", "Systemutvikling", "Teamleder", "Arkitekt"],
+        "email": "bard@scelto.no",
+        "linkedIn": "bård-dybwad-kristensen-27b0422",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Bård har deltatt i analyse, estimering, utvikling og testing av n-lags web-applikasjoner, både som teamleder, arkitekt, utvikler og leder av test-team, og har meget gode kunnskap om alle nivåer i slike løsninger."
+        ]
+    },
+    "andreas": {
+        "name": "Andreas Nilsen",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Andreas",
+        "ingress": "Andreas er en seniorkonsulent med erfaring fra 2011. Han har i sin karriere jobbet med mange forskjellige teknologier innenfor forskjellige sektorer og domener som blant annet forsvar, elmarked, bank og finans, landbruk, helse, jordbruk, Statens Vegvesen og NAV.",
+        "keyFeatures": ["Systemutvikler Java"],
+        "email": "andreas@scelto.no",
+        "linkedIn": "andreas-nilsen-54bba941",
+        "twitter": "",
+        "github": "",
+        "mainSection": [
+            "Andreas er en erfaren DevOps/full-stack utvikler med hovedtyngde på teknologier i Java økosystemet. Han har nå hovedfokuset på Kotlin, Kafka og Kubernetes. Andreas har en spesiell interesse for nettsky, mikrotjenester og hendelsesbasert arkitektur.",
+            "Andreas liker å jobbe tett med kunden, for på denne måten skape et mest mulig verdiøkende tjenestetilbud som er lønnsomt for alle parter. Han er en engasjert person som lett å samarbebide med, han er aktiv i fagmiljø og opptatt av å lære seg nye ting. Ingen utfordring er for stor, det er bare mer motiverende."
+        ]
+    },
+    "hallvard": {
+        "name": "Hallvard Stark",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Hallvard",
+        "ingress": "Hallvard har jobbet med webutvikling siden 2011, i en rekke prosjekter i forskjellige sektorer. Han er vant til å jobbe tett sammen med design og UX for å skape gode og brukervennlige løsninger på nett og mobil.",
+        "keyFeatures": [
+            "Frontendutvikler",
+            "React",
+            "NodeJS",
+            "HTML5/CSS3",
+            "Gatsby"
+        ],
+        "email": "hallvard@scelto.no",
+        "linkedIn": "",
+        "twitter": "ehallvard",
+        "github": "ehallvard",
+        "mainSection": [
+            "Konsulentjobben har gjort at han er godt til å samarbeide og tilpasse seg ulike miljøer. I reMarkable har han hatt rollen som utvikler med ansvar for den helhetlige utviklingen av selskapets nettsider og nettbutikk. Hallvard har god kjennskap og erfaring med universell utforming.",
+            "Han er en imøtekommende, hyggelig og rolig person som er opptatt av å gjøre godt og grundig arbeid som han kan være stolt av. Han er alltid nysgjerrig på å lære mer innenfor fagfeltet, og han lærer villig bort av sin egen kunnskap.",
+            "På fritiden liker Hallvard å lage mat, reise og oppleve nye destinasjoner og ta seg en løpetur så fort anledningen byr seg."
+        ]
+    },
+    "ismar": {
+        "name": "Ismar Slomic",
+        "title": "Seniorkonsulent",
+        "endOfContract": "2019-12-31",
+        "firstName": "Ismar",
+        "ingress": "Ismar har 11 års erfaring som systemutvikler, senior teknisk arkitekt og teknisk teamleder med solid erfaring fra store og komplekse prosjekter innenfor offentlig og privat sektor som Ruter, Sparebank 1, Statens Vegvesen, Statnett, Telenor og NAV.",
+        "keyFeatures": [
+            "Fullstack utvikler",
+            "Senior teknisk arkitekt",
+            "Agile/DevOps Coach",
+            "Mikrotjenester",
+            "Cloud-teknologi"
+        ],
+        "email": "ismar@scelto.no",
+        "linkedIn": "ismarslomic",
+        "twitter": "",
+        "github": "ismarslomic",
+        "mainSection": [
+            "Han er en engasjert utvikler som brenner for faget og streber etter kontinuerlig kompetanseheving samtidig som han deler denne med andre rundt seg. Selv om Ismar har lang erfaring som teknisk arkitekt er han opptatt av å være hands-on på teknologien og har benyttet enhver anledning til  scripting og programmering, både på prosjekter og i fritiden slik at han vedlikeholder og utvikler sine programmerinsferdigheter.",
+            "Han er en full-stack utvikler, som håndterer like godt front-end som back-end. Han brenner for mikrotjenestearkitektur, Domain Driven Design, kontainerarkitektur, hendelsesdrevet arkitektur, Cloudteknologi, DevOps, Lean og software craftmanship.",
+            "Han setter brukeren i sentrum og fokuserer på å forstå forretningsbehovene før han anbefaler og implementerer teknisk løsning. Ismar er opptatt av kvalitet gjennom hele arbeidsprosessen og er flink til å komme med forslag til forbedringstiltak. Han har også erfaring med håndtering av teknisk gjeld og prioritering av tekniske brukerhistorier for å redusere disse.",
+            "Ismar har høy arbeidskapasitet, er strukturert og ansvarsfull og opptatt av å levere resultater til avtalt tid. Han jobber selvstendig, men er også åpen og lett å samarbeide med. Han har hatt flere roller på prosjekter hvor han har hatt ansvar for opplæring og coaching av andre.",
+            "Ismar er opptatt av å se helheten og evner å bevege seg i ulike abstraksjonsnivåer og kommunisere komplekse problemstillinger på forståelig måte med ulike interessenter. Han har flere kurs og sertifiseringer innenfor teknisk arkitektur, som f.eks Togaf 9, Archimate 2, Domain Driven Design og  CQRS.",
+            "På fritiden liker han å se på nye smarthus-løsninger og er en nyfrelst yoga entusiast."
+        ]
+    }
+]

--- a/src/pages/ansatte/alle-ansatte.jsx
+++ b/src/pages/ansatte/alle-ansatte.jsx
@@ -46,7 +46,7 @@ const IndexPage = props => {
                     margin: '50px 20px 0',
                 }}
             >
-                {sortedAnsatte.map(({ name, title, key }) => {
+                {props.pageContext.ansatte.map(({ name, title, key }) => {
                     const image = props.data.EmployeeImages.edges.find(
                         node => node.node.name === key
                     );

--- a/src/pages/forsiden.jsx
+++ b/src/pages/forsiden.jsx
@@ -15,7 +15,6 @@ import Footer from '../components/Footer';
 import { LightButton, DarkButton } from '../components/Button';
 import { createMetadata } from '../utils';
 import DefaultEmployeeImage from '../images/mugshots/no-pic-yet.jpg';
-import { sortedAnsatte } from '../ansatte-med-assets';
 
 import '../layouts/scelto.less';
 import './index.less';
@@ -59,24 +58,27 @@ const IndexPage = props => {
                             justifyContent: 'center',
                         }}
                     >
-                        {sortedAnsatte.map(({ name, title, key }) => {
-                            const image = props.data.EmployeeImages.edges.find(
-                                node => node.node.name === key
-                            );
-                            return (
-                                <EmployeeImageLink
-                                    key={key}
-                                    image={
-                                        (image &&
-                                            image.node.childImageSharp.fixed) ||
-                                        DefaultEmployeeImage
-                                    }
-                                    name={name}
-                                    title={title}
-                                    to={`/ansatte/${key}`}
-                                />
-                            );
-                        })}
+                        {props.pageContext.ansatte.map(
+                            ({ name, title, key }) => {
+                                const image = props.data.EmployeeImages.edges.find(
+                                    node => node.node.name === key
+                                );
+                                return (
+                                    <EmployeeImageLink
+                                        key={key}
+                                        image={
+                                            (image &&
+                                                image.node.childImageSharp
+                                                    .fixed) ||
+                                            DefaultEmployeeImage
+                                        }
+                                        name={name}
+                                        title={title}
+                                        to={`/ansatte/${key}`}
+                                    />
+                                );
+                            }
+                        )}
                     </div>
                     <div className="sc-button-container">
                         <DarkButton to="/ansatte" text="Se alle konsulentene" />


### PR DESCRIPTION
Jeg lekte litt med gatsby i kveld og lurte på om dette var en god ide. Kanskje @hallvardastark, the master of gatsby, kan guide meg til riktig strategi.

Målet:

- [x] alle ansatte på `/ansatte` skal sorteres etter prosjektets end-date
- [ ] i tillegg til ☝️ skal vi kun vise de tre første på forsiden
- [ ] når datagrunnlaget endres ved commit blir forsiden og ansatte-siden oppdatert i byggesteget